### PR TITLE
Correct set name

### DIFF
--- a/GameDatabase/30c200c9-6c98-49a4-a293-106c06295c05/sets/8247133c-a928-4437-a602-2001cc3d3ba4/set.xml
+++ b/GameDatabase/30c200c9-6c98-49a4-a293-106c06295c05/sets/8247133c-a928-4437-a602-2001cc3d3ba4/set.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 
-<set name="05-Lions of the Rock"
+<set name="05-Lions of Casterly Rock"
      id="8247133c-a928-4437-a602-2001cc3d3ba4"
      gameId="30c200c9-6c98-49a4-a293-106c06295c05"
      gameVersion="2.0.0.27"


### PR DESCRIPTION
Lions of the Rock was the name of the Lannister box in 1st edition.